### PR TITLE
Pin actions/setup-java and maven-dependency-submission-action to SHA

### DIFF
--- a/.github/workflows/build-java-17.yml
+++ b/.github/workflows/build-java-17.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up JDK 17
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
       with:
         java-version: 17
         distribution: corretto
@@ -36,4 +36,4 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: ${{ github.repository }}
     - name: Submit Dependency Snapshot
-      uses: advanced-security/maven-dependency-submission-action@v5
+      uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # v5.0.0

--- a/.github/workflows/codeql-java-17.yml
+++ b/.github/workflows/codeql-java-17.yml
@@ -65,7 +65,7 @@ jobs:
         queries: security-and-quality
 
     # Attempting compatibiltiy with Java 17
-    - uses: actions/setup-java@v5
+    - uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
       with:
         java-version: 17
         distribution: corretto


### PR DESCRIPTION
Pin `actions/setup-java@v5` and `advanced-security/maven-dependency-submission-action@v5` to verified commit SHAs.

- `actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0`
- `advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # v5.0.0`